### PR TITLE
Add CUDA deps-only base image for BOUT-dev CI

### DIFF
--- a/.github/workflows/ci-cuda.yml
+++ b/.github/workflows/ci-cuda.yml
@@ -43,6 +43,7 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: ci-cuda/
+          target: setup-spack
           push: true
           shm-size: '256M'
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/ci-cuda.yml
+++ b/.github/workflows/ci-cuda.yml
@@ -20,9 +20,6 @@ jobs:
       contents: read
       packages: write
 
-    strategy:
-      fail-fast: true
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -39,14 +36,12 @@ jobs:
         uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=boutdev-cuda
 
       - name: Build and push Docker image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
-          build-args: |
-            MPI=${{ matrix.mpi }}
-            TYPE=${{ matrix.type }}
-            OPENMP=${{ matrix.config.openmp }}
           context: ci-cuda/
           push: true
           shm-size: '256M'

--- a/.github/workflows/ci-cuda.yml
+++ b/.github/workflows/ci-cuda.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=boutdev-cuda
+            type=raw,value=ci-cuda
 
       - name: Build and push Docker image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83

--- a/.github/workflows/ci-cuda.yml
+++ b/.github/workflows/ci-cuda.yml
@@ -1,4 +1,4 @@
-name: CI Fedora
+name: CI CUDA
 
 on:
   push:
@@ -47,7 +47,7 @@ jobs:
             MPI=${{ matrix.mpi }}
             TYPE=${{ matrix.type }}
             OPENMP=${{ matrix.config.openmp }}
-          context: ci-fedora/
+          context: ci-cuda/
           push: true
           shm-size: '256M'
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/ci-cuda.yml
+++ b/.github/workflows/ci-cuda.yml
@@ -1,0 +1,54 @@
+name: CI Fedora
+
+on:
+  push:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Run on the 7th of each month at 13:37 to ensure the image stays up-to-date
+    - cron:  '37 13 7 * *'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build container image
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        with:
+          build-args: |
+            MPI=${{ matrix.mpi }}
+            TYPE=${{ matrix.type }}
+            OPENMP=${{ matrix.config.openmp }}
+          context: ci-fedora/
+          push: true
+          shm-size: '256M'
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/ci-cuda/Dockerfile
+++ b/ci-cuda/Dockerfile
@@ -1,12 +1,12 @@
-# BOUT++ CUDA-enabled Docker container
-# This Dockerfile builds BOUT++ with CUDA support using Spack for dependency management
+# BOUT++ CUDA dependencies base image
+# Provides Spack-managed CUDA toolchain for BOUT-dev CI
+# BOUT-dev CI handles cloning/building BOUT++ itself
 
 FROM docker.io/nvidia/cuda:12.6.1-devel-ubuntu22.04 AS base
 LABEL maintainer="BOUT++ Development Team"
 USER root
 
 # Install system dependencies
-# Using Ubuntu 22.04 for more recent toolchain and better CUDA support
 RUN \
  apt update &&\
  DEBIAN_FRONTEND=noninteractive TZ=America/Los_Angeles apt install -y \
@@ -24,7 +24,8 @@ RUN \
    curl \
    libcurl4-openssl-dev \
    gfortran \
-   ca-certificates &&\
+   ca-certificates \
+   libssl-dev &&\
  apt upgrade -y &&\
  apt clean
 
@@ -44,69 +45,20 @@ RUN \
  spack add "umpire@2024.07.0+cuda~examples+numa+openmp cuda_arch=${CUDA_ARCH}" &&\
  spack add "raja@2024.07.0+cuda~examples~exercises+openmp cuda_arch=${CUDA_ARCH}" &&\
  spack add fmt@11.0.2 &&\
- spack add netcdf-cxx4@4.3.1 &&\
- spack add fftw@3.3.10 &&\
+ spack add 'netcdf-cxx4@4.3.1 ^mpich' &&\
+ spack add 'fftw@3.3.10 ^mpich' &&\
  spack external find --not-buildable &&\
- spack external find perl cuda bzip2 pkgconfig ncurses mpich curl --not-buildable &&\
- spack install -j$(nproc)
+ spack external find perl cuda bzip2 pkgconfig ncurses mpich curl openssl --not-buildable &&\
+ spack install --show-log-on-error -j$(nproc)
 
 # Set up environment variables for the build
 ENV SPACK_ROOT=/spack
 ENV PATH="${SPACK_ROOT}/bin:${PATH}"
 
-FROM setup-spack AS bout-build
-
-ARG CUDA_ARCH=80
-
-# Create boutuser (for consistency with existing Docker setup)
-RUN useradd -m -s /bin/bash boutuser && \
-    echo "boutuser:boutforever" | chpasswd && \
-    usermod -aG sudo boutuser
-
-USER boutuser
-WORKDIR /home/boutuser
-
-ARG BOUT_URL=https://github.com/boutproject/BOUT-dev.git
-ARG BOUT_COMMIT=next
-
-WORKDIR /home/boutuser
-
-# Activate Spack environment and configure BOUT++ with CUDA
-USER root
-RUN . /spack/share/spack/setup-env.sh && \
-    spack env activate /spack-env && \
-    spack load cmake && \
-    spack load fmt && \
-    spack load raja && \
-    spack load umpire && \
-    spack load netcdf-cxx4 && \
-    spack load fftw && \
-    chown -R boutuser:boutuser /home/boutuser
-
-RUN echo '# Setup spack for BOUT++\n\
+# Helper script for activating the Spack environment
+RUN echo '#!/bin/bash\n\
 . /spack/share/spack/setup-env.sh\n\
 spack env activate /spack-env\n\
 spack load cmake fmt raja umpire netcdf-cxx4 fftw\n\
-' > /usr/local/bin/bout-env.bash
-
-USER boutuser
-
-RUN git clone ${BOUT_URL} BOUT-dev && \
-    cd BOUT-dev && \
-    git checkout ${BOUT_COMMIT} && \
-    . /usr/local/bin/bout-env.bash && \
-    git submodule update --init --recursive && \
-    cmake -S . \
-            -B build \
-            -DCMAKE_C_COMPILER=gcc \
-            -DCMAKE_CXX_COMPILER=g++ \
-            -DBOUT_ENABLE_RAJA=on \
-            -DBOUT_ENABLE_UMPIRE=on \
-            -DBOUT_ENABLE_CUDA=on \
-            -DCMAKE_CUDA_ARCHITECTURES=80 \
-            -DCUDA_ARCH=compute_80,code=sm_80 \
-            -DBOUT_ENABLE_WARNINGS=off \
-            -DBOUT_USE_SYSTEM_FMT=on && \
-      cd build && \
-      make -j 2 build-check && \
-      make check && cd ../.. && rm -rf BOUT-dev
+' > /usr/local/bin/bout-env.bash && \
+    chmod +x /usr/local/bin/bout-env.bash

--- a/ci-cuda/Dockerfile
+++ b/ci-cuda/Dockerfile
@@ -62,3 +62,27 @@ spack env activate /spack-env\n\
 spack load cmake fmt raja umpire netcdf-cxx4 fftw\n\
 ' > /usr/local/bin/bout-env.bash && \
     chmod +x /usr/local/bin/bout-env.bash
+
+# Validate the image by building and testing BOUT++
+ARG BOUT_URL=https://github.com/boutproject/BOUT-dev.git
+ARG BOUT_COMMIT=next
+
+RUN git clone ${BOUT_URL} BOUT-dev && \
+    cd BOUT-dev && \
+    git checkout ${BOUT_COMMIT} && \
+    . /usr/local/bin/bout-env.bash && \
+    git submodule update --init --recursive && \
+    cmake -S . \
+            -B build \
+            -DCMAKE_C_COMPILER=gcc \
+            -DCMAKE_CXX_COMPILER=g++ \
+            -DBOUT_ENABLE_RAJA=on \
+            -DBOUT_ENABLE_UMPIRE=on \
+            -DBOUT_ENABLE_CUDA=on \
+            -DCMAKE_CUDA_ARCHITECTURES=80 \
+            -DCUDA_ARCH=compute_80,code=sm_80 \
+            -DBOUT_ENABLE_WARNINGS=off \
+            -DBOUT_USE_SYSTEM_FMT=on && \
+      cd build && \
+      make -j 2 build-check && \
+      make check && cd ../.. && rm -rf BOUT-dev

--- a/ci-cuda/Dockerfile
+++ b/ci-cuda/Dockerfile
@@ -44,7 +44,7 @@ RUN \
  spack add blt@0.6.2 &&\
  spack add "umpire@2024.07.0+cuda~examples+numa+openmp cuda_arch=${CUDA_ARCH}" &&\
  spack add "raja@2024.07.0+cuda~examples~exercises+openmp cuda_arch=${CUDA_ARCH}" &&\
- spack add fmt@11.0.2 &&\
+ spack add fmt@10.2.1 &&\
  spack add 'netcdf-cxx4@4.3.1 ^mpich' &&\
  spack add 'fftw@3.3.10 ^mpich' &&\
  spack external find --not-buildable &&\
@@ -63,9 +63,24 @@ spack load cmake fmt raja umpire netcdf-cxx4 fftw\n\
 ' > /usr/local/bin/bout-env.bash && \
     chmod +x /usr/local/bin/bout-env.bash
 
-# Validate the image by building and testing BOUT++
+# Install Python packages required by BOUT++
+RUN pip3 install --no-cache-dir \
+    "Jinja2>=3.1.4" \
+    "numpy>=2.0.0" \
+    "scipy>=1.14.1" \
+    "netcdf4>=1.7.1" \
+    "matplotlib>=3.7.0" \
+    "Cython>=3.0.0" \
+    "boutdata>=0.3.0" \
+    "zoidberg>=0.2.2"
+
+# Validate: build BOUT++ (requires --gpus all when running this stage)
+# Usage: docker build --target validate --build-arg CUDA_ARCH=<arch> ci-cuda/
+FROM setup-spack AS validate
+
 ARG BOUT_URL=https://github.com/boutproject/BOUT-dev.git
 ARG BOUT_COMMIT=next
+ARG CUDA_ARCH=80
 
 RUN git clone ${BOUT_URL} BOUT-dev && \
     cd BOUT-dev && \
@@ -80,8 +95,8 @@ RUN git clone ${BOUT_URL} BOUT-dev && \
             -DBOUT_ENABLE_RAJA=on \
             -DBOUT_ENABLE_UMPIRE=on \
             -DBOUT_ENABLE_CUDA=on \
-            -DCMAKE_CUDA_ARCHITECTURES=80 \
-            -DCUDA_ARCH=compute_80,code=sm_80 \
+            -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCH} \
+            -DCUDA_ARCH=compute_${CUDA_ARCH},code=sm_${CUDA_ARCH} \
             -DBOUT_ENABLE_WARNINGS=off \
             -DBOUT_USE_SYSTEM_FMT=on && \
       cd build && \

--- a/ci-cuda/Dockerfile
+++ b/ci-cuda/Dockerfile
@@ -1,6 +1,5 @@
 # BOUT++ CUDA-enabled Docker container
 # This Dockerfile builds BOUT++ with CUDA support using Spack for dependency management
-# Fixes issue #3233 by using updated fmt library version
 
 FROM docker.io/nvidia/cuda:12.6.1-devel-ubuntu22.04 AS base
 LABEL maintainer="BOUT++ Development Team"
@@ -67,16 +66,10 @@ RUN useradd -m -s /bin/bash boutuser && \
 USER boutuser
 WORKDIR /home/boutuser
 
-# Clone and build BOUT++
 ARG BOUT_URL=https://github.com/boutproject/BOUT-dev.git
-ARG BOUT_COMMIT=master
+ARG BOUT_COMMIT=next
 
-RUN git clone ${BOUT_URL} BOUT-dev && \
-    cd BOUT-dev && \
-    git checkout ${BOUT_COMMIT} && \
-    git submodule update --init --recursive
-
-WORKDIR /home/boutuser/BOUT-dev
+WORKDIR /home/boutuser
 
 # Activate Spack environment and configure BOUT++ with CUDA
 USER root
@@ -88,52 +81,32 @@ RUN . /spack/share/spack/setup-env.sh && \
     spack load umpire && \
     spack load netcdf-cxx4 && \
     spack load fftw && \
-    chown -R boutuser:boutuser /home/boutuser/BOUT-dev
+    chown -R boutuser:boutuser /home/boutuser
 
-USER boutuser
-
-# Configure BOUT++ with CUDA support
-# CUDA_ARCH is set via build arg (default: 80 for Ampere/A100)
-RUN . /spack/share/spack/setup-env.sh && \
-    spack env activate /spack-env && \
-    spack load cmake fmt raja umpire netcdf-cxx4 fftw && \
-    cmake -S . -B build \
-      -DCMAKE_INSTALL_PREFIX=/opt/bout++ \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DBOUT_ENABLE_CUDA=ON \
-      -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCH} \
-      -DCUDA_ARCH="compute_${CUDA_ARCH},code=sm_${CUDA_ARCH}" \
-      -DBOUT_ENABLE_RAJA=ON \
-      -DBOUT_ENABLE_UMPIRE=ON \
-      -DBOUT_USE_SYSTEM_FMT=ON \
-      -DBOUT_GENERATE_FIELDOPS=OFF \
-      -DBOUT_ENABLE_PYTHON=ON \
-      || (cat /home/boutuser/BOUT-dev/build/CMakeFiles/CMake{Output,Error}.log ; exit 1)
-
-# Build BOUT++
-RUN . /spack/share/spack/setup-env.sh && \
-    spack env activate /spack-env && \
-    spack load cmake fmt raja umpire netcdf-cxx4 fftw && \
-    cmake --build build -j$(nproc)
-
-# Install BOUT++
-USER root
-RUN . /spack/share/spack/setup-env.sh && \
-    spack env activate /spack-env && \
-    spack load cmake && \
-    cmake --install build
-
-# Create a helper script to activate the Spack environment
-RUN echo '#!/bin/bash\n\
+RUN echo '# Setup spack for BOUT++\n\
 . /spack/share/spack/setup-env.sh\n\
 spack env activate /spack-env\n\
 spack load cmake fmt raja umpire netcdf-cxx4 fftw\n\
-exec "$@"' > /usr/local/bin/bout-env.sh && \
-    chmod +x /usr/local/bin/bout-env.sh
+' > /usr/local/bin/bout-env.bash
 
 USER boutuser
-WORKDIR /home/boutuser/BOUT-dev
 
-# Default command activates Spack environment and drops to bash
-ENTRYPOINT ["/usr/local/bin/bout-env.sh"]
-CMD ["/bin/bash"]
+RUN git clone ${BOUT_URL} BOUT-dev && \
+    cd BOUT-dev && \
+    git checkout ${BOUT_COMMIT} && \
+    . /usr/local/bin/bout-env.bash && \
+    git submodule update --init --recursive && \
+    cmake -S . \
+            -B build \
+            -DCMAKE_C_COMPILER=gcc \
+            -DCMAKE_CXX_COMPILER=g++ \
+            -DBOUT_ENABLE_RAJA=on \
+            -DBOUT_ENABLE_UMPIRE=on \
+            -DBOUT_ENABLE_CUDA=on \
+            -DCMAKE_CUDA_ARCHITECTURES=80 \
+            -DCUDA_ARCH=compute_80,code=sm_80 \
+            -DBOUT_ENABLE_WARNINGS=off \
+            -DBOUT_USE_SYSTEM_FMT=on && \
+      cd build && \
+      make -j 2 build-check && \
+      make check && cd ../.. && rm -rf BOUT-dev

--- a/ci-cuda/Dockerfile
+++ b/ci-cuda/Dockerfile
@@ -76,6 +76,7 @@ RUN git clone ${BOUT_URL} BOUT-dev && \
             -B build \
             -DCMAKE_C_COMPILER=gcc \
             -DCMAKE_CXX_COMPILER=g++ \
+            -DCMAKE_CUDA_HOST_COMPILER=gcc \
             -DBOUT_ENABLE_RAJA=on \
             -DBOUT_ENABLE_UMPIRE=on \
             -DBOUT_ENABLE_CUDA=on \

--- a/ci-cuda/Dockerfile
+++ b/ci-cuda/Dockerfile
@@ -1,0 +1,139 @@
+# BOUT++ CUDA-enabled Docker container
+# This Dockerfile builds BOUT++ with CUDA support using Spack for dependency management
+# Fixes issue #3233 by using updated fmt library version
+
+FROM docker.io/nvidia/cuda:12.6.1-devel-ubuntu22.04 AS base
+LABEL maintainer="BOUT++ Development Team"
+USER root
+
+# Install system dependencies
+# Using Ubuntu 22.04 for more recent toolchain and better CUDA support
+RUN \
+ apt update &&\
+ DEBIAN_FRONTEND=noninteractive TZ=America/Los_Angeles apt install -y \
+   build-essential \
+   git \
+   software-properties-common \
+   python3 \
+   python3-pip \
+   wget \
+   mpich \
+   libmpich-dev \
+   unzip \
+   libnuma-dev \
+   libncurses-dev \
+   curl \
+   libcurl4-openssl-dev \
+   gfortran \
+   ca-certificates &&\
+ apt upgrade -y &&\
+ apt clean
+
+FROM base AS setup-spack
+
+# CUDA architecture: 70=Volta, 75=Turing, 80=Ampere, 89=Ada, 90=Hopper
+ARG CUDA_ARCH=80
+
+# Install Spack and set up environment
+RUN \
+ git clone --depth 1 --single-branch --branch v0.23.0 https://github.com/spack/spack.git &&\
+ . /spack/share/spack/setup-env.sh &&\
+ spack env create -d /spack-env &&\
+ spack env activate /spack-env &&\
+ spack add cmake@3.24: &&\
+ spack add blt@0.6.2 &&\
+ spack add "umpire@2024.07.0+cuda~examples+numa+openmp cuda_arch=${CUDA_ARCH}" &&\
+ spack add "raja@2024.07.0+cuda~examples~exercises+openmp cuda_arch=${CUDA_ARCH}" &&\
+ spack add fmt@11.0.2 &&\
+ spack add netcdf-cxx4@4.3.1 &&\
+ spack add fftw@3.3.10 &&\
+ spack external find --not-buildable &&\
+ spack external find perl cuda bzip2 pkgconfig ncurses mpich curl --not-buildable &&\
+ spack install -j$(nproc)
+
+# Set up environment variables for the build
+ENV SPACK_ROOT=/spack
+ENV PATH="${SPACK_ROOT}/bin:${PATH}"
+
+FROM setup-spack AS bout-build
+
+ARG CUDA_ARCH=80
+
+# Create boutuser (for consistency with existing Docker setup)
+RUN useradd -m -s /bin/bash boutuser && \
+    echo "boutuser:boutforever" | chpasswd && \
+    usermod -aG sudo boutuser
+
+USER boutuser
+WORKDIR /home/boutuser
+
+# Clone and build BOUT++
+ARG BOUT_URL=https://github.com/boutproject/BOUT-dev.git
+ARG BOUT_COMMIT=master
+
+RUN git clone ${BOUT_URL} BOUT-dev && \
+    cd BOUT-dev && \
+    git checkout ${BOUT_COMMIT} && \
+    git submodule update --init --recursive
+
+WORKDIR /home/boutuser/BOUT-dev
+
+# Activate Spack environment and configure BOUT++ with CUDA
+USER root
+RUN . /spack/share/spack/setup-env.sh && \
+    spack env activate /spack-env && \
+    spack load cmake && \
+    spack load fmt && \
+    spack load raja && \
+    spack load umpire && \
+    spack load netcdf-cxx4 && \
+    spack load fftw && \
+    chown -R boutuser:boutuser /home/boutuser/BOUT-dev
+
+USER boutuser
+
+# Configure BOUT++ with CUDA support
+# CUDA_ARCH is set via build arg (default: 80 for Ampere/A100)
+RUN . /spack/share/spack/setup-env.sh && \
+    spack env activate /spack-env && \
+    spack load cmake fmt raja umpire netcdf-cxx4 fftw && \
+    cmake -S . -B build \
+      -DCMAKE_INSTALL_PREFIX=/opt/bout++ \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBOUT_ENABLE_CUDA=ON \
+      -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCH} \
+      -DCUDA_ARCH="compute_${CUDA_ARCH},code=sm_${CUDA_ARCH}" \
+      -DBOUT_ENABLE_RAJA=ON \
+      -DBOUT_ENABLE_UMPIRE=ON \
+      -DBOUT_USE_SYSTEM_FMT=ON \
+      -DBOUT_GENERATE_FIELDOPS=OFF \
+      -DBOUT_ENABLE_PYTHON=ON \
+      || (cat /home/boutuser/BOUT-dev/build/CMakeFiles/CMake{Output,Error}.log ; exit 1)
+
+# Build BOUT++
+RUN . /spack/share/spack/setup-env.sh && \
+    spack env activate /spack-env && \
+    spack load cmake fmt raja umpire netcdf-cxx4 fftw && \
+    cmake --build build -j$(nproc)
+
+# Install BOUT++
+USER root
+RUN . /spack/share/spack/setup-env.sh && \
+    spack env activate /spack-env && \
+    spack load cmake && \
+    cmake --install build
+
+# Create a helper script to activate the Spack environment
+RUN echo '#!/bin/bash\n\
+. /spack/share/spack/setup-env.sh\n\
+spack env activate /spack-env\n\
+spack load cmake fmt raja umpire netcdf-cxx4 fftw\n\
+exec "$@"' > /usr/local/bin/bout-env.sh && \
+    chmod +x /usr/local/bin/bout-env.sh
+
+USER boutuser
+WORKDIR /home/boutuser/BOUT-dev
+
+# Default command activates Spack environment and drops to bash
+ENTRYPOINT ["/usr/local/bin/bout-env.sh"]
+CMD ["/bin/bash"]

--- a/ci-cuda/README.md
+++ b/ci-cuda/README.md
@@ -1,0 +1,120 @@
+# BOUT++ CUDA Docker Container
+
+This directory contains a Dockerfile for building BOUT++ with CUDA support.
+
+## Changes from Previous Version
+
+This Dockerfile addresses issue [#3233](https://github.com/boutproject/BOUT-dev/issues/3233) by updating dependencies:
+
+- **Ubuntu**: 20.04 → 22.04 (better toolchain and CUDA support)
+- **CUDA**: 12.2.2 → 12.6.1 (latest stable release)
+- **Spack**: v0.21.1 → v0.23.0 (improved package management)
+- **fmt**: 10.0.0 → 11.0.2 (fixes missing `fmt/base.h` header)
+- **RAJA**: 2022.10.4 → 2024.07.0 (improved CUDA support)
+- **Umpire**: 2022.03.1 → 2024.07.0 (improved memory management)
+- **BLT**: 0.5.3 → 0.6.2 (build system updates)
+
+## Prerequisites
+
+- Docker or Podman installed
+- NVIDIA Docker runtime (nvidia-docker2) for GPU access
+- NVIDIA GPU with Compute Capability 8.0+ (Ampere or newer)
+  - For other architectures, use the `CUDA_ARCH` build arg (see below)
+
+## Building the Container
+
+### Basic build:
+```bash
+cd .docker/cuda
+docker build -t bout-cuda:latest .
+```
+
+### Build with specific BOUT++ commit:
+```bash
+docker build \
+  --build-arg BOUT_URL=https://github.com/boutproject/BOUT-dev.git \
+  --build-arg BOUT_COMMIT=<commit-hash-or-branch> \
+  -t bout-cuda:custom .
+```
+
+## Running the Container
+
+### Interactive shell:
+```bash
+docker run --gpus all -it bout-cuda:latest
+```
+
+### Run with mounted directory:
+```bash
+docker run --gpus all -it \
+  -v $(pwd):/workspace \
+  -w /workspace \
+  bout-cuda:latest
+```
+
+### Check CUDA availability:
+```bash
+docker run --gpus all -it bout-cuda:latest bash -c "nvidia-smi && nvcc --version"
+```
+
+## GPU Architecture Notes
+
+The default build targets NVIDIA A100 GPUs (Ampere, `cuda_arch=80`).
+
+For other GPU architectures, pass the `CUDA_ARCH` build arg:
+
+```bash
+# For Volta (V100)
+docker build --build-arg CUDA_ARCH=70 -t bout-cuda:volta .
+
+# For Hopper (H100)
+docker build --build-arg CUDA_ARCH=90 -t bout-cuda:hopper .
+
+# Or using the build script
+./build.sh --cuda-arch 70
+```
+
+Common CUDA architectures:
+- **70**: Volta (V100)
+- **75**: Turing (RTX 20 series, T4)
+- **80**: Ampere (A100, RTX 30 series)
+- **86**: Ampere (RTX 30 mobile, A10, A40)
+- **89**: Ada Lovelace (RTX 40 series)
+- **90**: Hopper (H100)
+
+## Troubleshooting
+
+### Spack build failures
+If Spack fails to build packages, try increasing Docker memory allocation (minimum 8GB recommended).
+
+### CUDA runtime errors
+Ensure nvidia-docker2 is properly installed:
+```bash
+# Test NVIDIA runtime
+docker run --rm --gpus all nvidia/cuda:12.6.1-base-ubuntu22.04 nvidia-smi
+```
+
+### fmt header issues
+If you encounter `fmt/base.h` not found errors, ensure you're using fmt 11.0+ (this is configured by default).
+
+## Container Layout
+
+- BOUT++ source: `/home/boutuser/BOUT-dev`
+- BOUT++ install: `/opt/bout++`
+- Spack environment: `/spack-env`
+- Helper script: `/usr/local/bin/bout-env.sh` (loads Spack environment)
+
+## Environment Activation
+
+The container's entrypoint automatically activates the Spack environment. If you need to manually activate it:
+
+```bash
+. /spack/share/spack/setup-env.sh
+spack env activate /spack-env
+spack load cmake fmt raja umpire netcdf-cxx4 fftw
+```
+
+Or simply use the helper script:
+```bash
+/usr/local/bin/bout-env.sh <your-command>
+```

--- a/ci-cuda/README.md
+++ b/ci-cuda/README.md
@@ -1,13 +1,6 @@
 # BOUT++ CUDA Base Image
 
-Dependencies-only base container for BOUT-dev CUDA CI. Provides a Spack-managed
-toolchain (CUDA 12.6, RAJA, Umpire, fmt, NetCDF, FFTW) on Ubuntu 22.04.
-
-BOUT-dev CI pulls this image and handles cloning/building BOUT++ itself.
-
-## Image
-
-Published to `ghcr.io/boutproject/bout-container-base:boutdev-cuda`.
+Dependencies-only base container for BOUT-dev CUDA CI.
 
 ## Spack environment activation
 
@@ -23,5 +16,5 @@ The image is rebuilt monthly by CI and on every push to `ci-cuda`.
 To build locally:
 
 ```bash
-docker build -t boutdev-cuda:latest ci-cuda/
+docker build -t ci-cuda:latest ci-cuda/
 ```

--- a/ci-cuda/README.md
+++ b/ci-cuda/README.md
@@ -1,118 +1,27 @@
-# BOUT++ CUDA Docker Container
+# BOUT++ CUDA Base Image
 
-This directory contains a Dockerfile for building BOUT++ with CUDA support.
+Dependencies-only base container for BOUT-dev CUDA CI. Provides a Spack-managed
+toolchain (CUDA 12.6, RAJA, Umpire, fmt, NetCDF, FFTW) on Ubuntu 22.04.
 
-## Changes from Previous Version
+BOUT-dev CI pulls this image and handles cloning/building BOUT++ itself.
 
-This Dockerfile addresses issue [#3233](https://github.com/boutproject/BOUT-dev/issues/3233) by updating dependencies:
+## Image
 
-- **Ubuntu**: 20.04 → 22.04 (better toolchain and CUDA support)
-- **CUDA**: 12.2.2 → 12.6.1 (latest stable release)
-- **Spack**: v0.21.1 → v0.23.0 (improved package management)
-- **fmt**: 10.0.0 → 11.0.2 (fixes missing `fmt/base.h` header)
-- **RAJA**: 2022.10.4 → 2024.07.0 (improved CUDA support)
-- **Umpire**: 2022.03.1 → 2024.07.0 (improved memory management)
-- **BLT**: 0.5.3 → 0.6.2 (build system updates)
+Published to `ghcr.io/boutproject/bout-container-base:boutdev-cuda`.
 
-## Prerequisites
+## Spack environment activation
 
-- Docker or Podman installed
-- NVIDIA Docker runtime (nvidia-docker2) for GPU access
-- NVIDIA GPU with Compute Capability 8.0+ (Ampere or newer)
-  - For other architectures, use the `CUDA_ARCH` build arg (see below)
+Inside the container, source the helper script:
 
-## Building the Container
-
-### Basic build:
 ```bash
-cd .docker/cuda
-docker build -t bout-cuda:latest .
+. /usr/local/bin/bout-env.bash
 ```
 
-### Build with specific BOUT++ commit:
-```bash
-docker build \
-  --build-arg BOUT_URL=https://github.com/boutproject/BOUT-dev.git \
-  --build-arg BOUT_COMMIT=<commit-hash-or-branch> \
-  -t bout-cuda:custom .
-```
+## Rebuilding
 
-## Running the Container
-
-### Interactive shell:
-```bash
-docker run --gpus all -it bout-cuda:latest
-```
-
-### Run with mounted directory:
-```bash
-docker run --gpus all -it \
-  -v $(pwd):/workspace \
-  -w /workspace \
-  bout-cuda:latest
-```
-
-### Check CUDA availability:
-```bash
-docker run --gpus all -it bout-cuda:latest bash -c "nvidia-smi && nvcc --version"
-```
-
-## GPU Architecture Notes
-
-The default build targets NVIDIA A100 GPUs (Ampere, `cuda_arch=80`).
-
-For other GPU architectures, pass the `CUDA_ARCH` build arg:
+The image is rebuilt monthly by CI and on every push to `ci-cuda`.
+To build locally:
 
 ```bash
-# For Volta (V100)
-docker build --build-arg CUDA_ARCH=70 -t bout-cuda:volta .
-
-# For Hopper (H100)
-docker build --build-arg CUDA_ARCH=90 -t bout-cuda:hopper .
-
-```
-
-Common CUDA architectures:
-- **70**: Volta (V100)
-- **75**: Turing (RTX 20 series, T4)
-- **80**: Ampere (A100, RTX 30 series)
-- **86**: Ampere (RTX 30 mobile, A10, A40)
-- **89**: Ada Lovelace (RTX 40 series)
-- **90**: Hopper (H100)
-
-## Troubleshooting
-
-### Spack build failures
-If Spack fails to build packages, try increasing Docker memory allocation (minimum 8GB recommended).
-
-### CUDA runtime errors
-Ensure nvidia-docker2 is properly installed:
-```bash
-# Test NVIDIA runtime
-docker run --rm --gpus all nvidia/cuda:12.6.1-base-ubuntu22.04 nvidia-smi
-```
-
-### fmt header issues
-If you encounter `fmt/base.h` not found errors, ensure you're using fmt 11.0+ (this is configured by default).
-
-## Container Layout
-
-- BOUT++ source: `/home/boutuser/BOUT-dev`
-- BOUT++ install: `/opt/bout++`
-- Spack environment: `/spack-env`
-- Helper script: `/usr/local/bin/bout-env.sh` (loads Spack environment)
-
-## Environment Activation
-
-The container's entrypoint automatically activates the Spack environment. If you need to manually activate it:
-
-```bash
-. /spack/share/spack/setup-env.sh
-spack env activate /spack-env
-spack load cmake fmt raja umpire netcdf-cxx4 fftw
-```
-
-Or simply use the helper script:
-```bash
-/usr/local/bin/bout-env.sh <your-command>
+docker build -t boutdev-cuda:latest ci-cuda/
 ```

--- a/ci-cuda/README.md
+++ b/ci-cuda/README.md
@@ -70,8 +70,6 @@ docker build --build-arg CUDA_ARCH=70 -t bout-cuda:volta .
 # For Hopper (H100)
 docker build --build-arg CUDA_ARCH=90 -t bout-cuda:hopper .
 
-# Or using the build script
-./build.sh --cuda-arch 70
 ```
 
 Common CUDA architectures:


### PR DESCRIPTION
## Summary

Adds a CUDA dependencies base image (`ci-cuda/`) for use by BOUT-dev CI. This supersedes PR #39 with the following improvements:

- **Dockerfile**: deps-only image (no BOUT++ clone/build — BOUT-dev CI handles that)
  - Added `libssl-dev` to apt packages (required by libevent/OpenSSL for Spack builds)
  - Added `^mpich` constraint to `netcdf-cxx4` and `fftw` specs (prevents building OpenMPI from source)
  - Added `openssl` to `spack external find`
  - Added `--show-log-on-error` to `spack install`
  - Added `/usr/local/bin/bout-env.bash` helper script for activating the Spack env
  - Removed `bout-build` stage, hardcoded password, and boutuser creation
- **CI workflow**: removed unused matrix build-args (`MPI`, `TYPE`, `OPENMP`); set image tag to `boutdev-cuda`
- **README**: simplified to reflect deps-only purpose

Publishes to `ghcr.io/boutproject/bout-container-base:boutdev-cuda`.

Companion PR: https://github.com/boutproject/BOUT-dev/pull/3272

Fixes https://github.com/boutproject/BOUT-dev/issues/3233

## Test plan

- [ ] CI builds the CUDA image successfully
- [ ] BOUT-dev CUDA CI job pulls the new image and builds BOUT++

🤖 Generated with [Claude Code](https://claude.com/claude-code)