### PR TITLE
Make ci-cuda a deps-only base image for BOUT-dev CI

### DIFF
--- a/.github/workflows/ci-cuda.yml
+++ b/.github/workflows/ci-cuda.yml
@@ -20,9 +20,6 @@ jobs:
       contents: read
       packages: write
 
-    strategy:
-      fail-fast: true
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -39,14 +36,12 @@ jobs:
         uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=boutdev-cuda
 
       - name: Build and push Docker image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
-          build-args: |
-            MPI=${{ matrix.mpi }}
-            TYPE=${{ matrix.type }}
-            OPENMP=${{ matrix.config.openmp }}
           context: ci-cuda/
           push: true
           shm-size: '256M'

--- a/ci-cuda/Dockerfile
+++ b/ci-cuda/Dockerfile
@@ -1,12 +1,12 @@
-# BOUT++ CUDA-enabled Docker container
-# This Dockerfile builds BOUT++ with CUDA support using Spack for dependency management
+# BOUT++ CUDA dependencies base image
+# Provides Spack-managed CUDA toolchain for BOUT-dev CI
+# BOUT-dev CI handles cloning/building BOUT++ itself
 
 FROM docker.io/nvidia/cuda:12.6.1-devel-ubuntu22.04 AS base
 LABEL maintainer="BOUT++ Development Team"
 USER root
 
 # Install system dependencies
-# Using Ubuntu 22.04 for more recent toolchain and better CUDA support
 RUN \
  apt update &&\
  DEBIAN_FRONTEND=noninteractive TZ=America/Los_Angeles apt install -y \
@@ -24,7 +24,8 @@ RUN \
    curl \
    libcurl4-openssl-dev \
    gfortran \
-   ca-certificates &&\
+   ca-certificates \
+   libssl-dev &&\
  apt upgrade -y &&\
  apt clean
 
@@ -44,69 +45,20 @@ RUN \
  spack add "umpire@2024.07.0+cuda~examples+numa+openmp cuda_arch=${CUDA_ARCH}" &&\
  spack add "raja@2024.07.0+cuda~examples~exercises+openmp cuda_arch=${CUDA_ARCH}" &&\
  spack add fmt@11.0.2 &&\
- spack add netcdf-cxx4@4.3.1 &&\
- spack add fftw@3.3.10 &&\
+ spack add 'netcdf-cxx4@4.3.1 ^mpich' &&\
+ spack add 'fftw@3.3.10 ^mpich' &&\
  spack external find --not-buildable &&\
- spack external find perl cuda bzip2 pkgconfig ncurses mpich curl --not-buildable &&\
- spack install -j$(nproc)
+ spack external find perl cuda bzip2 pkgconfig ncurses mpich curl openssl --not-buildable &&\
+ spack install --show-log-on-error -j$(nproc)
 
 # Set up environment variables for the build
 ENV SPACK_ROOT=/spack
 ENV PATH="${SPACK_ROOT}/bin:${PATH}"
 
-FROM setup-spack AS bout-build
-
-ARG CUDA_ARCH=80
-
-# Create boutuser (for consistency with existing Docker setup)
-RUN useradd -m -s /bin/bash boutuser && \
-    echo "boutuser:boutforever" | chpasswd && \
-    usermod -aG sudo boutuser
-
-USER boutuser
-WORKDIR /home/boutuser
-
-ARG BOUT_URL=https://github.com/boutproject/BOUT-dev.git
-ARG BOUT_COMMIT=next
-
-WORKDIR /home/boutuser
-
-# Activate Spack environment and configure BOUT++ with CUDA
-USER root
-RUN . /spack/share/spack/setup-env.sh && \
-    spack env activate /spack-env && \
-    spack load cmake && \
-    spack load fmt && \
-    spack load raja && \
-    spack load umpire && \
-    spack load netcdf-cxx4 && \
-    spack load fftw && \
-    chown -R boutuser:boutuser /home/boutuser
-
-RUN echo '# Setup spack for BOUT++\n\
+# Helper script for activating the Spack environment
+RUN echo '#!/bin/bash\n\
 . /spack/share/spack/setup-env.sh\n\
 spack env activate /spack-env\n\
 spack load cmake fmt raja umpire netcdf-cxx4 fftw\n\
-' > /usr/local/bin/bout-env.bash
-
-USER boutuser
-
-RUN git clone ${BOUT_URL} BOUT-dev && \
-    cd BOUT-dev && \
-    git checkout ${BOUT_COMMIT} && \
-    . /usr/local/bin/bout-env.bash && \
-    git submodule update --init --recursive && \
-    cmake -S . \
-            -B build \
-            -DCMAKE_C_COMPILER=gcc \
-            -DCMAKE_CXX_COMPILER=g++ \
-            -DBOUT_ENABLE_RAJA=on \
-            -DBOUT_ENABLE_UMPIRE=on \
-            -DBOUT_ENABLE_CUDA=on \
-            -DCMAKE_CUDA_ARCHITECTURES=80 \
-            -DCUDA_ARCH=compute_80,code=sm_80 \
-            -DBOUT_ENABLE_WARNINGS=off \
-            -DBOUT_USE_SYSTEM_FMT=on && \
-      cd build && \
-      make -j 2 build-check && \
-      make check && cd ../.. && rm -rf BOUT-dev
+' > /usr/local/bin/bout-env.bash && \
+    chmod +x /usr/local/bin/bout-env.bash

--- a/ci-cuda/README.md
+++ b/ci-cuda/README.md
@@ -1,118 +1,27 @@
-# BOUT++ CUDA Docker Container
+# BOUT++ CUDA Base Image
 
-This directory contains a Dockerfile for building BOUT++ with CUDA support.
+Dependencies-only base container for BOUT-dev CUDA CI. Provides a Spack-managed
+toolchain (CUDA 12.6, RAJA, Umpire, fmt, NetCDF, FFTW) on Ubuntu 22.04.
 
-## Changes from Previous Version
+BOUT-dev CI pulls this image and handles cloning/building BOUT++ itself.
 
-This Dockerfile addresses issue [#3233](https://github.com/boutproject/BOUT-dev/issues/3233) by updating dependencies:
+## Image
 
-- **Ubuntu**: 20.04 → 22.04 (better toolchain and CUDA support)
-- **CUDA**: 12.2.2 → 12.6.1 (latest stable release)
-- **Spack**: v0.21.1 → v0.23.0 (improved package management)
-- **fmt**: 10.0.0 → 11.0.2 (fixes missing `fmt/base.h` header)
-- **RAJA**: 2022.10.4 → 2024.07.0 (improved CUDA support)
-- **Umpire**: 2022.03.1 → 2024.07.0 (improved memory management)
-- **BLT**: 0.5.3 → 0.6.2 (build system updates)
+Published to `ghcr.io/boutproject/bout-container-base:boutdev-cuda`.
 
-## Prerequisites
+## Spack environment activation
 
-- Docker or Podman installed
-- NVIDIA Docker runtime (nvidia-docker2) for GPU access
-- NVIDIA GPU with Compute Capability 8.0+ (Ampere or newer)
-  - For other architectures, use the `CUDA_ARCH` build arg (see below)
+Inside the container, source the helper script:
 
-## Building the Container
-
-### Basic build:
 ```bash
-cd .docker/cuda
-docker build -t bout-cuda:latest .
+. /usr/local/bin/bout-env.bash
 ```
 
-### Build with specific BOUT++ commit:
-```bash
-docker build \
-  --build-arg BOUT_URL=https://github.com/boutproject/BOUT-dev.git \
-  --build-arg BOUT_COMMIT=<commit-hash-or-branch> \
-  -t bout-cuda:custom .
-```
+## Rebuilding
 
-## Running the Container
-
-### Interactive shell:
-```bash
-docker run --gpus all -it bout-cuda:latest
-```
-
-### Run with mounted directory:
-```bash
-docker run --gpus all -it \
-  -v $(pwd):/workspace \
-  -w /workspace \
-  bout-cuda:latest
-```
-
-### Check CUDA availability:
-```bash
-docker run --gpus all -it bout-cuda:latest bash -c "nvidia-smi && nvcc --version"
-```
-
-## GPU Architecture Notes
-
-The default build targets NVIDIA A100 GPUs (Ampere, `cuda_arch=80`).
-
-For other GPU architectures, pass the `CUDA_ARCH` build arg:
+The image is rebuilt monthly by CI and on every push to `ci-cuda`.
+To build locally:
 
 ```bash
-# For Volta (V100)
-docker build --build-arg CUDA_ARCH=70 -t bout-cuda:volta .
-
-# For Hopper (H100)
-docker build --build-arg CUDA_ARCH=90 -t bout-cuda:hopper .
-
-```
-
-Common CUDA architectures:
-- **70**: Volta (V100)
-- **75**: Turing (RTX 20 series, T4)
-- **80**: Ampere (A100, RTX 30 series)
-- **86**: Ampere (RTX 30 mobile, A10, A40)
-- **89**: Ada Lovelace (RTX 40 series)
-- **90**: Hopper (H100)
-
-## Troubleshooting
-
-### Spack build failures
-If Spack fails to build packages, try increasing Docker memory allocation (minimum 8GB recommended).
-
-### CUDA runtime errors
-Ensure nvidia-docker2 is properly installed:
-```bash
-# Test NVIDIA runtime
-docker run --rm --gpus all nvidia/cuda:12.6.1-base-ubuntu22.04 nvidia-smi
-```
-
-### fmt header issues
-If you encounter `fmt/base.h` not found errors, ensure you're using fmt 11.0+ (this is configured by default).
-
-## Container Layout
-
-- BOUT++ source: `/home/boutuser/BOUT-dev`
-- BOUT++ install: `/opt/bout++`
-- Spack environment: `/spack-env`
-- Helper script: `/usr/local/bin/bout-env.sh` (loads Spack environment)
-
-## Environment Activation
-
-The container's entrypoint automatically activates the Spack environment. If you need to manually activate it:
-
-```bash
-. /spack/share/spack/setup-env.sh
-spack env activate /spack-env
-spack load cmake fmt raja umpire netcdf-cxx4 fftw
-```
-
-Or simply use the helper script:
-```bash
-/usr/local/bin/bout-env.sh <your-command>
+docker build -t boutdev-cuda:latest ci-cuda/
 ```


### PR DESCRIPTION
- Add libssl-dev to apt packages (required by libevent/OpenSSL for Spack)
- Add ^mpich constraint to netcdf-cxx4 and fftw (prevents building OpenMPI)
- Add openssl to spack external find
- Add --show-log-on-error to spack install
- Add /usr/local/bin/bout-env.bash helper script
- Remove bout-build stage (BOUT-dev CI handles cloning/building)
- Remove hardcoded password and boutuser creation
- Remove unused matrix build-args from CI workflow
- Set image tag to boutdev-cuda
- Simplify README to reflect deps-only purpose